### PR TITLE
update for deprecated pyvisa import

### DIFF
--- a/KepcoMotorController.py
+++ b/KepcoMotorController.py
@@ -1,4 +1,5 @@
-import visa, time
+import time
+import pyvisa as visa
 
 from sardana import State
 from sardana.pool.controller import MotorController


### PR DESCRIPTION
pyvisa complains that importing just "visa" is deprecated due to possible incompatibilities with identically named "visa" package